### PR TITLE
feature/annotation

### DIFF
--- a/src/main/java/com/mss/prm_project/controller/PaperController.java
+++ b/src/main/java/com/mss/prm_project/controller/PaperController.java
@@ -5,7 +5,6 @@ import com.mss.prm_project.dto.PaperDTO;
 import com.mss.prm_project.entity.Paper;
 import com.mss.prm_project.service.PaperService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
 
@@ -42,11 +42,12 @@ public class PaperController {
     }
 
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-        public ResponseEntity<PaperDTO> uploadPaper(@RequestPart("dto") PaperDTO dto, @RequestParam("publishDate") String publishDate, @RequestParam("file") MultipartFile file) throws IOException {
+    public ResponseEntity<PaperDTO> uploadPaper(@RequestPart("dto") PaperDTO dto, @RequestParam("publishDate") String publishDate, @RequestParam("file") MultipartFile file) throws IOException {
         if(Objects.isNull(dto.getPriority())) {
             dto.setPriority(1);
         }
-        LocalDateTime localDateTime = LocalDateTime.parse(publishDate);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        LocalDateTime localDateTime = LocalDate.parse(publishDate, formatter).atStartOfDay();
         dto.setPublishDate(localDateTime);
         PaperDTO result = paperService.insertPaper(dto, file);
         return ResponseEntity.ok(result);
@@ -55,6 +56,12 @@ public class PaperController {
     @PostMapping( "/add-to-favourite")
     public ResponseEntity<FavoritePaperDTO> addToFavoritePapers(@RequestParam("userId") long userId , @RequestParam("paperId") long paperId ) {
         FavoritePaperDTO result = paperService.addtoFavoritePapers(userId, paperId);
+        return ResponseEntity.ok(result);
+    }
+
+    @DeleteMapping( "/{id}")
+    public ResponseEntity<Boolean> deletePaper( @PathVariable("id") long paperId ) {
+        boolean result = paperService.deletePaper(paperId);
         return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/mss/prm_project/repository/AnnotationRepository.java
+++ b/src/main/java/com/mss/prm_project/repository/AnnotationRepository.java
@@ -14,4 +14,6 @@ public interface AnnotationRepository extends JpaRepository<Annotation, Long> {
         WHERE r.userId = :userId
     """)
     List<Annotation> findAllReadableByUserId(@Param("userId") long userId);
+
+    Annotation findByPaperPaperIdAndOwnerUserId(int paperPaperId, int ownerUserId);
 }

--- a/src/main/java/com/mss/prm_project/service/serviceimpl/PaperServiceImpl.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/PaperServiceImpl.java
@@ -10,6 +10,7 @@ import com.mss.prm_project.mapper.PaperMapper;
 import com.mss.prm_project.mapper.UserMapper;
 import com.mss.prm_project.repository.*;
 import com.mss.prm_project.service.PaperService;
+import com.mss.prm_project.utils.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -71,6 +72,9 @@ public class PaperServiceImpl implements PaperService {
         file.setFileUrl("https://prm392-labverse.s3.ap-southeast-2.amazonaws.com/uploads/1760692462213_erd_prm.drawio.pdf");
         File savedfile = fileRepository.save(file);
         Paper paper = PaperMapper.INSTANCE.toEntity(dto);
+        String username = SecurityUtils.getCurrentUserName().get();
+        User user = userRepository.findByUsername(username).get();
+        paper.setUser(user);
         Paper savedPaper = paperRepository.save(paper);
         savedfile.setPaper(savedPaper);
         fileRepository.save(savedfile);

--- a/src/main/java/com/mss/prm_project/service/serviceimpl/PaperServiceImpl.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/PaperServiceImpl.java
@@ -126,6 +126,11 @@ public class PaperServiceImpl implements PaperService {
     @Override
     public PaperDTO findByPaperId(long paperId) {
         Paper paper = paperRepository.findById(paperId).orElseThrow(null);
-        return PaperMapper.INSTANCE.toDTO(paper);
+        PaperDTO dto =  PaperMapper.INSTANCE.toDTO(paper);
+        File file = fileRepository.findByPaperPaperId(paper.getPaperId());
+        if (file != null) {
+            dto.setFileUrl(file.getFileUrl());
+        }
+        return dto;
     }
 }

--- a/src/main/java/com/mss/prm_project/service/serviceimpl/S3ServiceV2.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/S3ServiceV2.java
@@ -51,12 +51,31 @@ public class S3ServiceV2 {
         }
     }
 
-    public void deleteFile(String key) {
+    public void deleteFile(String url) {
+        String filekey = this.extractFileKeyFromUrl(url);
         DeleteObjectRequest delReq = DeleteObjectRequest.builder()
                 .bucket(bucketName)
-                .key(key)
+                .key(filekey)
                 .build();
         s3.deleteObject(delReq);
+    }
+
+    private String extractFileKeyFromUrl(String fileUrl) {
+        String bucketName = "prm392-labverse";
+        String marker = bucketName + ".s3.";
+
+        int markerIndex = fileUrl.indexOf(marker);
+        if (markerIndex == -1) {
+            throw new IllegalArgumentException("Invalid S3 URL: missing bucket name");
+        }
+
+        // Tìm vị trí dấu "/" đầu tiên sau phần domain của S3
+        int startIndex = fileUrl.indexOf("/", markerIndex);
+        if (startIndex == -1 || startIndex + 1 >= fileUrl.length()) {
+            throw new IllegalArgumentException("Invalid S3 URL: missing file key");
+        }
+
+        return fileUrl.substring(startIndex + 1);
     }
 
     public String getBucketName() {


### PR DESCRIPTION
## Summary by Sourcery

Support updating annotations by replacing the existing file on S3, refactor S3 deletion logic to parse keys from URLs, and introduce a paper deletion endpoint in the controller

New Features:
- Allow overwriting existing annotations by deleting the old file and uploading a new one
- Add a DELETE /papers/{id} endpoint to remove papers

Enhancements:
- Update S3ServiceV2.deleteFile to accept full URLs and extract the file key internally
- Add findByPaperPaperIdAndOwnerUserId method to AnnotationRepository for fetching annotations by paper and owner