### PR TITLE
Feature/reading list

### DIFF
--- a/src/main/java/com/mss/prm_project/entity/Collection.java
+++ b/src/main/java/com/mss/prm_project/entity/Collection.java
@@ -4,7 +4,9 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -37,7 +39,7 @@ public class Collection extends BaseEntity {
             joinColumns = @JoinColumn(name = "collection_id"),
             inverseJoinColumns = @JoinColumn(name = "paper_id")
     )
-    Set<Paper> papers = new HashSet<>();
+    List<Paper> papers = new ArrayList<>();
 
 //    @ManyToMany
 //    @JoinTable(
@@ -48,5 +50,5 @@ public class Collection extends BaseEntity {
 //    Set<User> users = new HashSet<>();
 
     @OneToMany(mappedBy = "collection", cascade = CascadeType.ALL, orphanRemoval = true)
-    Set<CollectionMember> members = new HashSet<>();
+    List<CollectionMember> members = new ArrayList<>();
 }

--- a/src/main/java/com/mss/prm_project/entity/Paper.java
+++ b/src/main/java/com/mss/prm_project/entity/Paper.java
@@ -6,7 +6,9 @@ import lombok.experimental.FieldDefaults;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -52,6 +54,6 @@ public class Paper extends  BaseEntity {
     Set<Collection> collections = new HashSet<>();
 
     @ManyToMany(mappedBy = "papers")
-    private Set<ReadingList> readingLists = new HashSet<>();
+    private List<ReadingList> readingLists = new ArrayList<>();
 
 }

--- a/src/main/java/com/mss/prm_project/entity/Paper.java
+++ b/src/main/java/com/mss/prm_project/entity/Paper.java
@@ -52,5 +52,6 @@ public class Paper extends  BaseEntity {
     Set<Collection> collections = new HashSet<>();
 
     @ManyToMany(mappedBy = "papers")
-    Set<ReadingList> readingLists = new HashSet<>();
+    private Set<ReadingList> readingLists = new HashSet<>();
+
 }

--- a/src/main/java/com/mss/prm_project/entity/ReadingList.java
+++ b/src/main/java/com/mss/prm_project/entity/ReadingList.java
@@ -32,7 +32,7 @@ public class ReadingList extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     User ownerUser;
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.LAZY, cascade = {CascadeType.MERGE, CascadeType.PERSIST})
     @JoinTable(
             name = "reading_list_paper",
             joinColumns = @JoinColumn(name = "reading_id"),
@@ -40,7 +40,10 @@ public class ReadingList extends BaseEntity {
     )
     Set<Paper> papers = new HashSet<>();
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.LAZY, cascade = {
+            CascadeType.MERGE,
+            CascadeType.PERSIST
+    })
     @JoinTable(
             name = "reading_list_viewers", // Bảng nối mới
             joinColumns = @JoinColumn(name = "reading_id"),

--- a/src/main/java/com/mss/prm_project/entity/ReadingList.java
+++ b/src/main/java/com/mss/prm_project/entity/ReadingList.java
@@ -5,7 +5,9 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -38,7 +40,7 @@ public class ReadingList extends BaseEntity {
             joinColumns = @JoinColumn(name = "reading_id"),
             inverseJoinColumns = @JoinColumn(name = "paper_id")
     )
-    Set<Paper> papers = new HashSet<>();
+    List<Paper> papers = new ArrayList<>();
 
     @ManyToMany(fetch = FetchType.LAZY, cascade = {
             CascadeType.MERGE,
@@ -49,6 +51,6 @@ public class ReadingList extends BaseEntity {
             joinColumns = @JoinColumn(name = "reading_id"),
             inverseJoinColumns = @JoinColumn(name = "user_id")
     )
-    Set<User> viewers = new HashSet<>();
+    List<User> viewers = new ArrayList<>();
 
 }

--- a/src/main/java/com/mss/prm_project/entity/User.java
+++ b/src/main/java/com/mss/prm_project/entity/User.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -52,10 +53,10 @@ public class User extends BaseEntity implements UserDetails {
 //    Set<Collection> collections = new HashSet<>();
 
     @OneToMany(mappedBy = "ownerUser")
-    private Set<Collection> ownedCollections = new HashSet<>();
+    private List<Collection> ownedCollections = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Set<CollectionMember> memberOfCollections = new HashSet<>();
+    private List<CollectionMember> memberOfCollections = new ArrayList<>();
 
     @OneToMany(mappedBy = "user")
     List<Paper> paper;

--- a/src/main/java/com/mss/prm_project/model/PaperResponse.java
+++ b/src/main/java/com/mss/prm_project/model/PaperResponse.java
@@ -1,6 +1,9 @@
 package com.mss.prm_project.model;
 
 
+import lombok.Builder;
+
+@Builder
 public class PaperResponse {
     int paperId;
 
@@ -19,6 +22,7 @@ public class PaperResponse {
         this.author = author;
         this.journal = journal;
     }
+
 
     public int getPaperId() {
         return paperId;

--- a/src/main/java/com/mss/prm_project/repository/ReadingListRepository.java
+++ b/src/main/java/com/mss/prm_project/repository/ReadingListRepository.java
@@ -4,6 +4,7 @@ import com.mss.prm_project.entity.ReadingList;
 import com.mss.prm_project.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,4 +18,14 @@ public interface ReadingListRepository extends JpaRepository<ReadingList, Long> 
 
     // 3. Kiểm tra quyền sở hữu
     Optional<ReadingList> findByReadingIdAndOwnerUserUserId(int listId, int ownerId);
+
+
+    @Query(value = """
+        SELECT COUNT(*) 
+        FROM reading_list_paper 
+        WHERE reading_id = :listId AND paper_id = :paperId
+        """, nativeQuery = true)
+    int countPaperInList(@Param("listId") int listId, @Param("paperId") int paperId);
+
+
 }

--- a/src/main/java/com/mss/prm_project/service/serviceimpl/PaperServiceImpl.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/PaperServiceImpl.java
@@ -84,7 +84,7 @@ public class PaperServiceImpl implements PaperService {
     @Override
     public List<PaperDTO> getPaperByPriority(long collectionid, int priority) {
         Collection collection = collectionRepository.findById(collectionid).get();
-        Set<Paper> paperList = collection.getPapers();
+        List<Paper> paperList = collection.getPapers();
         if(Objects.isNull(priority)){
             return paperList.stream().map(PaperMapper.INSTANCE::toDTO).toList();
         }else{

--- a/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingListServiceImpl.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingListServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collector;
@@ -54,7 +55,7 @@ public class ReadingListServiceImpl implements ReadingListService {
                 .name(name)
                 .description(description)
                 .ownerUser(owner)
-                .papers(new HashSet<>())
+                .papers(new ArrayList<>())
                 .build();
 
         newList = readingListRepository.save(newList);


### PR DESCRIPTION
## Summary by Sourcery

Refactor reading list and related entities to use ordered lists and improve add/remove operations

Enhancements:
- Change JPA many-to-many mappings in ReadingList, Collection, User, and Paper entities from Set to List with appropriate fetch and cascade configurations
- Add native countPaperInList query and explicit ownership and duplicate checks in addPaperToList before persisting changes
- Refactor ReadingListServiceImpl to use saveAndFlush, PaperResponse.builder for DTO mapping, and inject EntityManager