### PR TITLE
feature/annotation

### DIFF
--- a/src/main/java/com/mss/prm_project/controller/AnnotationController.java
+++ b/src/main/java/com/mss/prm_project/controller/AnnotationController.java
@@ -40,10 +40,10 @@ public class AnnotationController {
     }
 
     // API lấy tất cả các Annotation mà user có quyền đọc
-    @GetMapping("/readable/{userId}")
+    @GetMapping("/readable")
     public ResponseEntity<List<AnnotationDTO>> findAllReadableAnnotationByUserId(
-            @PathVariable long userId) {
-        List<AnnotationDTO> annotations = annotationService.findAllReadableAnnotationByUserId(userId);
+            @RequestParam("collectionMemberId") int collectionId, @RequestParam("paperId") long paperId) {
+        List<AnnotationDTO> annotations = annotationService.findAllReadableAnnotationByUserId(collectionId, paperId);
         return ResponseEntity.ok(annotations);
     }
 

--- a/src/main/java/com/mss/prm_project/controller/AnnotationController.java
+++ b/src/main/java/com/mss/prm_project/controller/AnnotationController.java
@@ -23,19 +23,19 @@ public class AnnotationController {
 
     // API chia sẻ quyền đọc cho user
     @PostMapping()
-    public ResponseEntity<Set<UserDTO>> shareReaderToAnnotation(
-            @RequestParam("annotationId") long annotationId,
-            @RequestParam("userId") long userId) {
-        Set<UserDTO> updatedReaders = annotationService.shareReaderToAnnotation(annotationId, userId);
+    public ResponseEntity<List<UserDTO>> shareAnnotationToOther(
+            @RequestParam("paperId") long paperId,
+            @RequestParam("userIdList") List<Long> userIdList) {
+        List<UserDTO> updatedReaders = annotationService.shareAnnotationToOther(paperId, userIdList);
         return ResponseEntity.ok(updatedReaders);
     }
 
     // API xóa quyền đọc của user
     @DeleteMapping("/{annotationId}/remove/{userId}")
-    public ResponseEntity<Set<UserDTO>> removeReaderFromAnnotation(
+    public ResponseEntity<List<UserDTO>> removeReaderFromAnnotation(
             @PathVariable long annotationId,
             @PathVariable long userId) {
-        Set<UserDTO> updatedReaders = annotationService.removeReaderFromAnnotation(annotationId, userId);
+        List<UserDTO> updatedReaders = annotationService.removeReaderFromAnnotation(annotationId, userId);
         return ResponseEntity.ok(updatedReaders);
     }
 

--- a/src/main/java/com/mss/prm_project/dto/AnnotationDTO.java
+++ b/src/main/java/com/mss/prm_project/dto/AnnotationDTO.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.Set;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -15,6 +15,6 @@ public class AnnotationDTO extends BaseDTO{
     String annotationName;
     String annotationUrl;
     UserDTO ownerDTO;
-    Set<UserDTO> readerDTO;
+    List<UserDTO> readerDTO;
     PaperDTO paperDTO;
 }

--- a/src/main/java/com/mss/prm_project/entity/Annotation.java
+++ b/src/main/java/com/mss/prm_project/entity/Annotation.java
@@ -3,8 +3,9 @@ package com.mss.prm_project.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
+
 
 @Entity
 @Getter
@@ -32,7 +33,7 @@ public class Annotation extends BaseEntity{
             joinColumns = @JoinColumn(name = "annotation_id"),
             inverseJoinColumns = @JoinColumn(name = "user_id")
     )
-    Set<User> readers = new HashSet<>();
+    List<User> readers = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_id", nullable = false)

--- a/src/main/java/com/mss/prm_project/mapper/AnnotationMapper.java
+++ b/src/main/java/com/mss/prm_project/mapper/AnnotationMapper.java
@@ -10,6 +10,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -31,17 +32,17 @@ public interface AnnotationMapper {
 
     // ====== Helper methods ======
 
-    default Set<UserDTO> mapReadersToDTO(Set<User> readers) {
+    default List<UserDTO> mapReadersToDTO(List<User> readers) {
         if (readers == null) return null;
         return readers.stream()
                 .map(UserMapper.INSTANCE::userToUserDTO)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
     }
 
-    default Set<User> mapDTOToReaders(Set<UserDTO> readerDTOs) {
+    default List<User> mapDTOToReaders(List<UserDTO> readerDTOs) {
         if (readerDTOs == null) return null;
         return readerDTOs.stream()
                 .map(UserMapper.INSTANCE::userDTOToUser)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/mss/prm_project/repository/AnnotationRepository.java
+++ b/src/main/java/com/mss/prm_project/repository/AnnotationRepository.java
@@ -16,4 +16,15 @@ public interface AnnotationRepository extends JpaRepository<Annotation, Long> {
     List<Annotation> findAllReadableByUserId(@Param("userId") long userId);
 
     Annotation findByPaperPaperIdAndOwnerUserId(int paperPaperId, int ownerUserId);
+
+    @Query("""
+        SELECT DISTINCT a
+        FROM Annotation a
+        LEFT JOIN a.readers r
+        WHERE (a.owner.userId = :userId OR r.userId = :userId)
+          AND a.paper.paperId = :paperId
+    """)
+    List<Annotation> findAllSharableByUserIdAndPaperId(@Param("userId") long userId,
+                                                       @Param("paperId") long paperId);
+
 }

--- a/src/main/java/com/mss/prm_project/service/AnnotationService.java
+++ b/src/main/java/com/mss/prm_project/service/AnnotationService.java
@@ -24,9 +24,9 @@ public interface AnnotationService {
     Set<UserDTO> removeReaderFromAnnotation(long annotationId, long userId);
 
     /**
-     * Lấy tất cả annotation mà user có quyền đọc
+     * Lấy tất cả annotation mà user có quyền đọc tương ứng với một Paper cụ thể
      */
-    List<AnnotationDTO> findAllReadableAnnotationByUserId(long userId);
+    List<AnnotationDTO> findAllReadableAnnotationByUserId(int collectionId, long paperId);
 
     /**
      * Lấy thông tin chi tiết của annotation theo id
@@ -44,4 +44,12 @@ public interface AnnotationService {
      * @return true nếu xóa thành công, false nếu không tồn tại
      */
     boolean deleteAnnotation(long annotationId);
+
+    /**
+     * Xóa annotation
+     * @return true nếu xóa thành công, false nếu không tồn tại
+     */
+    AnnotationDTO importAnnotationFromOtherMember(long annotationId, int paperId);
+
+
 }

--- a/src/main/java/com/mss/prm_project/service/AnnotationService.java
+++ b/src/main/java/com/mss/prm_project/service/AnnotationService.java
@@ -15,13 +15,13 @@ public interface AnnotationService {
      * Chia sẻ annotation cho 1 user cụ thể
      * @return AnnotationDTO sau khi đã thêm reader
      */
-    Set<UserDTO> shareReaderToAnnotation(long annotationId, long userId);
+    List<UserDTO> shareAnnotationToOther(long paperId, List<Long> userIdList);
 
     /**
      * Gỡ quyền đọc annotation khỏi user
      * @return AnnotationDTO sau khi đã cập nhật danh sách readers
      */
-    Set<UserDTO> removeReaderFromAnnotation(long annotationId, long userId);
+    List<UserDTO> removeReaderFromAnnotation(long annotationId, long userId);
 
     /**
      * Lấy tất cả annotation mà user có quyền đọc tương ứng với một Paper cụ thể

--- a/src/main/java/com/mss/prm_project/service/serviceimpl/PaperServiceImpl.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/PaperServiceImpl.java
@@ -64,8 +64,8 @@ public class PaperServiceImpl implements PaperService {
     @Override
     public PaperDTO insertPaper(PaperDTO dto, MultipartFile multipartFile) throws IOException {
         File file = new File();
-//        file.setFileUrl(s3ServiceV2.uploadFile(multipartFile));
-        file.setFileUrl("https://prm392-labverse.s3.ap-southeast-2.amazonaws.com/uploads/1760692462213_erd_prm.drawio.pdf");
+        file.setFileUrl(s3ServiceV2.uploadFile(multipartFile));
+//        file.setFileUrl("https://prm392-labverse.s3.ap-southeast-2.amazonaws.com/uploads/1760692462213_erd_prm.drawio.pdf");
         File savedfile = fileRepository.save(file);
         Paper paper = PaperMapper.INSTANCE.toEntity(dto);
         String username = SecurityUtils.getCurrentUserName().get();

--- a/src/main/java/com/mss/prm_project/service/serviceimpl/UserServiceImpl.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/UserServiceImpl.java
@@ -38,8 +38,11 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public Optional<UserDTO> getUserByEmail(String email) {
+        User user = userRepository.findByEmail(email).get();
         return userRepository.findByEmail(email)
+
                 .map(UserMapper.INSTANCE::userToUserDTO);
+
     }
 
     @Override

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,23 +1,23 @@
 spring.application.name=PRM_project
 ## MySQL
 #spring.datasource.password=123
-#spring.datasource.url=jdbc:mysql://localhost:3306/labverse_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
-#spring.datasource.username=labverse
-#spring.datasource.password=123
-#spring.jpa.hibernate.ddl-auto=update
-#spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
-#spring.jpa.properties.hibernate.format_sql=true
-#spring.jpa.properties.hibernate.show_sql=true
-#logging.level.org.springframework.cache=DEBUG
-
-spring.datasource.url=jdbc:mysql://localhost:3306/lab_verse
-spring.datasource.username=root
-spring.datasource.password=Root@123
+spring.datasource.url=jdbc:mysql://localhost:3306/labverse_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+spring.datasource.username=labverse
+spring.datasource.password=123
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.show_sql=true
 logging.level.org.springframework.cache=DEBUG
+
+#spring.datasource.url=jdbc:mysql://localhost:3306/lab_verse
+#spring.datasource.username=root
+#spring.datasource.password=Root@123
+#spring.jpa.hibernate.ddl-auto=update
+#spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+#spring.jpa.properties.hibernate.format_sql=true
+#spring.jpa.properties.hibernate.show_sql=true
+#logging.level.org.springframework.cache=DEBUG
 
 #spring.datasource.url=jdbc:mysql://localhost:3306/lab_verse
 #spring.datasource.username=root


### PR DESCRIPTION
## Summary by Sourcery

Enhance annotation sharing functionality by refactoring reader collections to lists, adding support for sharing annotations by paper and collection, and enabling import of annotations from other members. Update configuration and minor service implementations accordingly.

New Features:
- Add importAnnotationFromOtherMember API to allow copying an annotation URL from another user for a specific paper

Enhancements:
- Switch annotation readers from Set to List across entity, DTO, mapper, service, and controller layers
- Implement shareAnnotationToOther and removeReaderFromAnnotation to manage readers by paper context and return List<UserDTO]
- Extend findAllReadableAnnotationByUserId to filter annotations by collection membership and paper
- Introduce findAllSharableByUserIdAndPaperId repository query for fetching shareable annotations
- Rename and refactor controller endpoints and service methods for consistent annotation sharing semantics

Chores:
- Update application.properties to default to labverse_db and comment out alternative MySQL settings
- Re-enable S3 file upload in PaperServiceImpl and remove hardcoded file URL
- Refactor getUserByEmail in UserServiceImpl to retrieve entity before mapping