### PR TITLE
feature: fix authorName and ReadingProgressServiceImpl

### DIFF
--- a/src/main/java/com/mss/prm_project/controller/ReadingProgressController.java
+++ b/src/main/java/com/mss/prm_project/controller/ReadingProgressController.java
@@ -19,7 +19,7 @@ public class ReadingProgressController {
 
     @PostMapping("/create")
     public ResponseEntity<ReadingProgressDTO> createReadingProgress(
-            @RequestParam(value = "collectionId", required = false) int collectionId,
+            @RequestParam(value = "collectionId", defaultValue = "-1") int collectionId,
             @RequestParam("paperId") int paperId,
             @RequestParam("lastReadPage") int lastReadPage,
             @RequestParam("totalPages") int totalPages) {
@@ -28,9 +28,15 @@ public class ReadingProgressController {
         return new ResponseEntity<>(readingProgressDTO, HttpStatus.CREATED);
     }
 
+//    @GetMapping("/collection")
+//    public ResponseEntity<List<ReadingProgressDTO>> getAllReadingProgressByCollection(@RequestParam("collectionId") int collectionId, @RequestParam(value = "paperId", defaultValue = "0") int paperId) {
+//        List<ReadingProgressDTO> readingProgressDTOs = readingProgressService.getAllReadingProgressByCollection(collectionId, paperId);
+//        return new ResponseEntity<>(readingProgressDTOs, HttpStatus.OK);
+//    }
+
     @GetMapping("/collection")
-    public ResponseEntity<List<ReadingProgressDTO>> getAllReadingProgressByCollection(@RequestParam("collectionId") int collectionId, @RequestParam(value = "paperId", defaultValue = "0") int paperId) {
-        List<ReadingProgressDTO> readingProgressDTOs = readingProgressService.getAllReadingProgressByCollection(collectionId, paperId);
+    public ResponseEntity<List<ReadingProgressDTO>> getAllReadingProgressByCollection(@RequestParam("collectionId") int collectionId) {
+        List<ReadingProgressDTO> readingProgressDTOs = readingProgressService.getAllReadingProgressByCollection(collectionId);
         return new ResponseEntity<>(readingProgressDTOs, HttpStatus.OK);
     }
 

--- a/src/main/java/com/mss/prm_project/dto/PaperDTO.java
+++ b/src/main/java/com/mss/prm_project/dto/PaperDTO.java
@@ -11,6 +11,7 @@ public class PaperDTO extends BaseDTO{
     String title;
     String journal;
     String publisher;
+    String author;
     LocalDateTime publishDate;
     boolean isOffline;
     int priority;

--- a/src/main/java/com/mss/prm_project/service/ReadingProgressService.java
+++ b/src/main/java/com/mss/prm_project/service/ReadingProgressService.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 public interface ReadingProgressService {
     ReadingProgressDTO createReadingProgressForUserAndPaper(int collectionId, int paperId, int lastReadPage, int totalPages);
-    List<ReadingProgressDTO> getAllReadingProgressByCollection(int collectionId, int paperId);
+    List<ReadingProgressDTO> getAllReadingProgressByCollection(int collectionId);
     List<ReadingProgressDTO> getPersonalReadingProgress();
 }

--- a/src/main/java/com/mss/prm_project/service/serviceimpl/PaperServiceImpl.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/PaperServiceImpl.java
@@ -76,13 +76,11 @@ public class PaperServiceImpl implements PaperService {
         file.setFileUrl(s3ServiceV2.uploadFile(multipartFile));
 //        file.setFileUrl("https://prm392-labverse.s3.ap-southeast-2.amazonaws.com/uploads/1760692462213_erd_prm.drawio.pdf");
         File savedfile = fileRepository.save(file);
-
-        Paper paper = PaperMapper.INSTANCE.toEntity(dto);
-
         String username = SecurityUtils.getCurrentUserName().get();
         User user = userRepository.findByUsername(username).get();
+        Paper paper = PaperMapper.INSTANCE.toEntity(dto);
         paper.setUser(user);
-
+        paper.setAuthor(user.getFullName());
         paper.setCitationApa(toAPA(paper));
         paper.setCitationMla(toMLA(paper));
         paper.setCitationBibtex(toBibTeX(paper));

--- a/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingProgressServiceImpl.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingProgressServiceImpl.java
@@ -1,10 +1,7 @@
 package com.mss.prm_project.service.serviceimpl;
 
 import com.mss.prm_project.dto.ReadingProgressDTO;
-import com.mss.prm_project.entity.Collection;
-import com.mss.prm_project.entity.Paper;
-import com.mss.prm_project.entity.ReadingProgress;
-import com.mss.prm_project.entity.User;
+import com.mss.prm_project.entity.*;
 import com.mss.prm_project.mapper.ReadingProgressMapper;
 import com.mss.prm_project.repository.CollectionRepository;
 import com.mss.prm_project.repository.PaperRepository;
@@ -15,6 +12,7 @@ import com.mss.prm_project.utils.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -31,7 +29,7 @@ public class ReadingProgressServiceImpl implements ReadingProgressService {
         User user = userRepository.findByUsername(SecurityUtils.getCurrentUserName().get()).get();
         Paper paper = paperRepository.findById((long)paperId).orElseThrow(()-> new IllegalArgumentException("Paper not found"));
         Collection collection = collectionRepository.findById((long)collectionId).orElse(null);
-        ReadingProgress readingProgress = new ReadingProgress();
+        ReadingProgress readingProgress = null;
         if (collectionId >0) {
             readingProgress = readingProgressRepository.findByUserUserIdAndPaperPaperIdCollectionCollectionId(user.getUserId(), paperId, collectionId);
         }else {
@@ -41,11 +39,12 @@ public class ReadingProgressServiceImpl implements ReadingProgressService {
             readingProgress = new ReadingProgress();
             readingProgress.setUser(user);
             readingProgress.setPaper(paper);
-            readingProgress.setLatestPage(lastReadPage);
+            readingProgress.setLatestPage(0);
             if(Objects.nonNull(collection)) {
                 readingProgress.setCollection(collection);
             }
             readingProgress.setProgressStatus("To Read");
+            readingProgress.setCompletionPercent(BigDecimal.valueOf(0));
         }
         else {
             if(lastReadPage > readingProgress.getLatestPage()){
@@ -61,22 +60,68 @@ public class ReadingProgressServiceImpl implements ReadingProgressService {
     }
 
     @Override
-    public List<ReadingProgressDTO> getAllReadingProgressByCollection(int collectionId, int paperId) {
-        if(paperId != 0){
-            return readingProgressRepository.findByAndPaperPaperIdCollectionCollectionId(paperId, collectionId)
-                    .stream()
-                    .map(ReadingProgressMapper.INSTANCE::toDTO)
-                    .collect(Collectors.toList());
+    public List<ReadingProgressDTO> getAllReadingProgressByCollection(int collectionId) {
+        Collection collection = collectionRepository.findById((long)collectionId)
+                                .orElseThrow(()-> new IllegalArgumentException("Collection not found"));
+        List<CollectionMember> members = collection.getMembers();
+        List<User> users = members.stream()
+                                .map(CollectionMember::getUser)
+                                .toList();
+        List<Paper> papers = collection.getPapers();
+        List<ReadingProgress> results = new ArrayList<>();
+        for(User user : users){
+            for(Paper paper : papers) {
+                ReadingProgress readingProgress = readingProgressRepository.findByUserUserIdAndPaperPaperIdCollectionCollectionId(
+                        user.getUserId(),
+                        paper.getPaperId(),
+                        collectionId
+                );
+                if (readingProgress == null) {
+                    readingProgress = new ReadingProgress();
+                    readingProgress.setUser(user);
+                    readingProgress.setPaper(paper);
+                    readingProgress.setCollection(collection);
+                    readingProgress.setLatestPage(0);
+                    readingProgress.setProgressStatus("To Read");
+                    readingProgress.setCompletionPercent(BigDecimal.valueOf(0));
+                    ReadingProgress item = readingProgressRepository.save(readingProgress);
+                    results.add(item);
+                }else{
+                    results.add(readingProgress);
+                }
+            }
         }
-        List<ReadingProgress> readingProgressList = readingProgressRepository.getAllReadingProgressByCollectionCollectionId(collectionId);
-        return readingProgressList.stream().map(ReadingProgressMapper.INSTANCE::toDTO).collect(Collectors.toList());
+        return results.stream().map(ReadingProgressMapper.INSTANCE::toDTO).collect(Collectors.toList());
     }
 
     @Override
     public List<ReadingProgressDTO> getPersonalReadingProgress() {
         User user = userRepository.findByUsername(SecurityUtils.getCurrentUserName().get()).
                                     orElseThrow(()-> new IllegalArgumentException("User not found"));
-        List<ReadingProgress> readingProgressList = readingProgressRepository.getAllByUserUserId(user.getUserId());
-        return readingProgressList.stream().map(ReadingProgressMapper.INSTANCE::toDTO).collect(Collectors.toList());
+        List<Paper> papers = user.getPaper();
+        List<ReadingProgress> results = new ArrayList<>();
+        if(papers != null) {
+            for(Paper paper : papers){
+                ReadingProgress readingProgress = readingProgressRepository.findByUserUserIdAndPaperPaperId(
+                        user.getUserId(),
+                        paper.getPaperId()
+                );
+                if (readingProgress == null) {
+                    readingProgress = new ReadingProgress();
+                    readingProgress.setUser(user);
+                    readingProgress.setPaper(paper);
+                    readingProgress.setLatestPage(0);
+                    readingProgress.setProgressStatus("To Read");
+                    readingProgress.setCompletionPercent(BigDecimal.valueOf(0));
+                    ReadingProgress saveReadingProgress = readingProgressRepository.save(readingProgress);
+                    results.add(saveReadingProgress);
+                }
+                else{
+                    results.add(readingProgress);
+                }
+                return results.stream().map(ReadingProgressMapper.INSTANCE::toDTO).collect(Collectors.toList());
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Add author support for papers and revamp reading progress service to auto-generate and initialize progress entries with default values, with corresponding updates to controller and service interface.

New Features:
- Introduce author field in PaperDTO

Bug Fixes:
- Set paper author to the current user’s full name during insertion
- Initialize new ReadingProgress entries with default latestPage and completionPercent values

Enhancements:
- Refactor ReadingProgressServiceImpl to auto-create missing progress entries for all users and papers in a collection
- Simplify getAllReadingProgressByCollection and getPersonalReadingProgress to iterate and generate entries
- Update ReadingProgressController to accept only collectionId and remove deprecated paperId parameter