### PR TITLE
feature/annotation

### DIFF
--- a/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingProgressServiceImpl.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingProgressServiceImpl.java
@@ -43,8 +43,16 @@ public class ReadingProgressServiceImpl implements ReadingProgressService {
             if(Objects.nonNull(collection)) {
                 readingProgress.setCollection(collection);
             }
-            readingProgress.setProgressStatus("Reading");
             readingProgress.setCompletionPercent( BigDecimal.valueOf(((double) lastReadPage / totalPages) * 100));
+            String progressStatus;
+            if (lastReadPage == 0) {
+                progressStatus = "To Read";
+            } else if (lastReadPage == totalPages) {
+                progressStatus = "Completed";
+            } else {
+                progressStatus = "Reading";
+            }
+            readingProgress.setProgressStatus(progressStatus);
         }
         else {
             if(lastReadPage > readingProgress.getLatestPage()){

--- a/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingProgressServiceImpl.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingProgressServiceImpl.java
@@ -39,12 +39,12 @@ public class ReadingProgressServiceImpl implements ReadingProgressService {
             readingProgress = new ReadingProgress();
             readingProgress.setUser(user);
             readingProgress.setPaper(paper);
-            readingProgress.setLatestPage(0);
+            readingProgress.setLatestPage(lastReadPage);
             if(Objects.nonNull(collection)) {
                 readingProgress.setCollection(collection);
             }
-            readingProgress.setProgressStatus("To Read");
-            readingProgress.setCompletionPercent(BigDecimal.valueOf(0));
+            readingProgress.setProgressStatus("Reading");
+            readingProgress.setCompletionPercent( BigDecimal.valueOf(((double) lastReadPage / totalPages) * 100));
         }
         else {
             if(lastReadPage > readingProgress.getLatestPage()){

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,7 @@ spring.application.name=PRM_project
 #spring.datasource.username=labverse
 #spring.datasource.password=123
 #spring.jpa.hibernate.ddl-auto=update
+#spring.sql.init.mode=never
 #spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 #spring.jpa.properties.hibernate.format_sql=true
 #spring.jpa.properties.hibernate.show_sql=true


### PR DESCRIPTION
fix ReadingProgress API

## Summary by Sourcery

Update ReadingProgressService to initialize and update reading progress based on the provided lastReadPage parameter, including dynamic calculation of completion percentage and status, and adjust application configuration to disable automatic SQL initialization.

Bug Fixes:
- Initialize ReadingProgress latestPage, completionPercent, and progressStatus correctly based on lastReadPage

Enhancements:
- Calculate completionPercent from lastReadPage and totalPages
- Determine progressStatus as To Read, Reading, or Completed based on lastReadPage

Chores:
- Add spring.sql.init.mode=never to application properties