### PR TITLE
feature: fix Reading List Logic

### DIFF
--- a/src/main/java/com/mss/prm_project/controller/PaperController.java
+++ b/src/main/java/com/mss/prm_project/controller/PaperController.java
@@ -107,7 +107,7 @@ public class PaperController {
         return ResponseEntity.ok(result);
     }
 
-    @PutMapping("change-priority")
+    @PutMapping("/change-priority")
     public ResponseEntity<PaperDTO> changePaperPriority(@RequestParam("paperId") long paperId, @RequestParam("priority") int priority) {
         PaperDTO result = paperService.changePaperPriority(paperId, priority);
         return ResponseEntity.ok(result);

--- a/src/main/java/com/mss/prm_project/entity/ReadingProgress.java
+++ b/src/main/java/com/mss/prm_project/entity/ReadingProgress.java
@@ -15,7 +15,7 @@ import java.math.BigDecimal;
 @Table(
         name = "reading_progress",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"user_id", "paper_id"})
+                @UniqueConstraint(columnNames = {"user_id", "paper_id", "collection_id"})
         }
 )
 public class ReadingProgress extends BaseEntity {

--- a/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingProgressServiceImpl.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingProgressServiceImpl.java
@@ -107,7 +107,6 @@ public class ReadingProgressServiceImpl implements ReadingProgressService {
         User user = userRepository.findByUsername(SecurityUtils.getCurrentUserName().get()).
                                     orElseThrow(()-> new IllegalArgumentException("User not found"));
         List<Paper> papers = user.getPaper();
-        List<ReadingProgress> results = new ArrayList<>();
         if(papers != null) {
             for(Paper paper : papers){
                 ReadingProgress readingProgress = readingProgressRepository.findByUserUserIdAndPaperPaperId(
@@ -122,14 +121,10 @@ public class ReadingProgressServiceImpl implements ReadingProgressService {
                     readingProgress.setProgressStatus("To Read");
                     readingProgress.setCompletionPercent(BigDecimal.valueOf(0));
                     ReadingProgress saveReadingProgress = readingProgressRepository.save(readingProgress);
-                    results.add(saveReadingProgress);
                 }
-                else{
-                    results.add(readingProgress);
-                }
-                return results.stream().map(ReadingProgressMapper.INSTANCE::toDTO).collect(Collectors.toList());
             }
         }
-        return null;
+        List<ReadingProgress> results = readingProgressRepository.getAllByUserUserId(user.getUserId());
+        return results.stream().map(ReadingProgressMapper.INSTANCE::toDTO).toList();
     }
 }


### PR DESCRIPTION
fix reading progress logic

## Summary by Sourcery

Refactor reading progress retrieval to always load persisted entries, correct endpoint mapping for paper priority changes, and extend the unique constraint on ReadingProgress to include collection_id.

Bug Fixes:
- Fix getPersonalReadingProgress to return a complete list of DTOs instead of early returning or null
- Fix PaperController change-priority mapping by adding a leading slash

Enhancements:
- Simplify ReadingProgressServiceImpl to fetch all progress records via repository
- Extend ReadingProgress entity’s unique constraint to include collection_id