### PR TITLE
feature/annotation

### DIFF
--- a/src/main/java/com/mss/prm_project/controller/PaperController.java
+++ b/src/main/java/com/mss/prm_project/controller/PaperController.java
@@ -113,6 +113,12 @@ public class PaperController {
         return ResponseEntity.ok(result);
     }
 
+    @GetMapping("/recently-read")
+    public ResponseEntity<List<PaperDTO>> getRecentlyReadPapers(@RequestParam("userId") int userId) {
+        return null;
+    }
+
+
 
     @GetMapping("/{id}/citation")
     public ResponseEntity<String> getCitation(@PathVariable int id, @RequestParam String style) {

--- a/src/main/java/com/mss/prm_project/repository/ReadingProgressRepository.java
+++ b/src/main/java/com/mss/prm_project/repository/ReadingProgressRepository.java
@@ -40,7 +40,7 @@ public interface ReadingProgressRepository extends JpaRepository<ReadingProgress
         WHERE rp.paper.paperId = :paperId
         AND rp.user.userId = :userId
     """)
-    ReadingProgress findByUserUserIdAndPaperPaperId( @Param("userId") int userId,@Param("paperId") int paperId);
+    List<ReadingProgress>  findByUserUserIdAndPaperPaperId( @Param("userId") int userId,@Param("paperId") int paperId);
 
     List<ReadingProgress> getAllByUserUserId(int userId);
 }

--- a/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingProgressServiceImpl.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingProgressServiceImpl.java
@@ -29,11 +29,12 @@ public class ReadingProgressServiceImpl implements ReadingProgressService {
         User user = userRepository.findByUsername(SecurityUtils.getCurrentUserName().get()).get();
         Paper paper = paperRepository.findById((long)paperId).orElseThrow(()-> new IllegalArgumentException("Paper not found"));
         Collection collection = collectionRepository.findById((long)collectionId).orElse(null);
+        List<ReadingProgress> checking = new ArrayList<>();
         ReadingProgress readingProgress = null;
         if (collectionId >0) {
             readingProgress = readingProgressRepository.findByUserUserIdAndPaperPaperIdCollectionCollectionId(user.getUserId(), paperId, collectionId);
         }else {
-            readingProgress = readingProgressRepository.findByUserUserIdAndPaperPaperId(user.getUserId(), paperId);
+            checking = readingProgressRepository.findByUserUserIdAndPaperPaperId(user.getUserId(), paperId);
         }
         if (readingProgress == null) {
             readingProgress = new ReadingProgress();
@@ -109,18 +110,18 @@ public class ReadingProgressServiceImpl implements ReadingProgressService {
         List<Paper> papers = user.getPaper();
         if(papers != null) {
             for(Paper paper : papers){
-                ReadingProgress readingProgress = readingProgressRepository.findByUserUserIdAndPaperPaperId(
+                List<ReadingProgress>  readingProgress = readingProgressRepository.findByUserUserIdAndPaperPaperId(
                         user.getUserId(),
                         paper.getPaperId()
                 );
                 if (readingProgress == null) {
-                    readingProgress = new ReadingProgress();
-                    readingProgress.setUser(user);
-                    readingProgress.setPaper(paper);
-                    readingProgress.setLatestPage(0);
-                    readingProgress.setProgressStatus("To Read");
-                    readingProgress.setCompletionPercent(BigDecimal.valueOf(0));
-                    ReadingProgress saveReadingProgress = readingProgressRepository.save(readingProgress);
+                    ReadingProgress newItem = new ReadingProgress();
+                    newItem.setUser(user);
+                    newItem.setPaper(paper);
+                    newItem.setLatestPage(0);
+                    newItem.setProgressStatus("To Read");
+                    newItem.setCompletionPercent(BigDecimal.valueOf(0));
+                    readingProgressRepository.save(newItem);
                 }
             }
         }


### PR DESCRIPTION
fix Reading Progress

## Summary by Sourcery

Refactor reading progress retrieval to support multiple entries per paper and add a stub endpoint for fetching a user’s recently read papers

New Features:
- Introduce a GET /recently-read endpoint stub in PaperController for retrieving recently read papers

Enhancements:
- Change ReadingProgressRepository.findByUserUserIdAndPaperPaperId to return a list of entries instead of a single record
- Update ReadingProgressServiceImpl to use list-based queries and initialize missing progress entries accordingly