### PR TITLE
feature/favourite-recent-read

### DIFF
--- a/src/main/java/com/mss/prm_project/controller/PaperController.java
+++ b/src/main/java/com/mss/prm_project/controller/PaperController.java
@@ -108,8 +108,8 @@ public class PaperController {
     }
 
     @DeleteMapping("/delete-favourite")
-    public ResponseEntity<Boolean> deleteFavoritePapers(@RequestParam("favoriteId") long favoriteId) {
-        boolean result = paperService.deleteFavoritePaper(favoriteId);
+    public ResponseEntity<Boolean> deleteFavoritePapers(@RequestParam("paperId") long paperId) {
+        boolean result = paperService.deleteFavoritePaper(paperId);
         return ResponseEntity.ok(result);
     }
 
@@ -124,13 +124,6 @@ public class PaperController {
         PaperDTO result = paperService.changePaperPriority(paperId, priority);
         return ResponseEntity.ok(result);
     }
-
-    @GetMapping("/recently-read")
-    public ResponseEntity<List<PaperDTO>> getRecentlyReadPapers(@RequestParam("userId") int userId) {
-        return null;
-    }
-
-
 
     @GetMapping("/{id}/citation")
     public ResponseEntity<String> getCitation(@PathVariable int id, @RequestParam String style) {

--- a/src/main/java/com/mss/prm_project/controller/ReadingProgressController.java
+++ b/src/main/java/com/mss/prm_project/controller/ReadingProgressController.java
@@ -45,4 +45,10 @@ public class ReadingProgressController {
         List<ReadingProgressDTO> results =  readingProgressService.getPersonalReadingProgress();
         return new ResponseEntity<>(results, HttpStatus.OK);
     }
+
+    @GetMapping("/recently-read")
+    public ResponseEntity<List<ReadingProgressDTO>> getRecentlyReadPapers() {
+        List<ReadingProgressDTO> results = readingProgressService.getRecentRead();
+        return new ResponseEntity<>(results, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/mss/prm_project/dto/ReadingProgressDTO.java
+++ b/src/main/java/com/mss/prm_project/dto/ReadingProgressDTO.java
@@ -16,5 +16,6 @@ public class ReadingProgressDTO {
     PaperDTO paper;
     int latestPage;
     String progressStatus;
+    String collectionName;
     BigDecimal completionPercent;
 }

--- a/src/main/java/com/mss/prm_project/mapper/ReadingProgressMapper.java
+++ b/src/main/java/com/mss/prm_project/mapper/ReadingProgressMapper.java
@@ -3,6 +3,7 @@ package com.mss.prm_project.mapper;
 import com.mss.prm_project.dto.ReadingProgressDTO;
 import com.mss.prm_project.entity.ReadingProgress;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper(uses =  {UserMapper.class, PaperMapper.class})
@@ -11,5 +12,6 @@ public interface ReadingProgressMapper {
 
     ReadingProgress toEntity(ReadingProgressDTO dto);
 
+    @Mapping(target = "collectionName", source = "collection.name")
     ReadingProgressDTO toDTO(ReadingProgress entity);
 }

--- a/src/main/java/com/mss/prm_project/repository/FavoritePaperRepository.java
+++ b/src/main/java/com/mss/prm_project/repository/FavoritePaperRepository.java
@@ -9,6 +9,8 @@ import java.util.List;
 
 @Repository
 public interface FavoritePaperRepository extends JpaRepository<FavoritePaper, Long> {
-    FavoritePaper findByUserUserIdAndPaperPaperId(@RequestParam Long userId, @RequestParam Long paperId);
+
+    FavoritePaper findByUserUserIdAndPaperPaperId(@RequestParam int userId, @RequestParam int paperId);
+
     List<FavoritePaper> findAllByUserUserId(@RequestParam int userId);
 }

--- a/src/main/java/com/mss/prm_project/repository/ReadingProgressRepository.java
+++ b/src/main/java/com/mss/prm_project/repository/ReadingProgressRepository.java
@@ -43,4 +43,7 @@ public interface ReadingProgressRepository extends JpaRepository<ReadingProgress
     List<ReadingProgress>  findByUserUserIdAndPaperPaperId( @Param("userId") int userId,@Param("paperId") int paperId);
 
     List<ReadingProgress> getAllByUserUserId(int userId);
+
+    List<ReadingProgress> getAllByUserUserIdOrderByUpdatedAt(int userId);
+
 }

--- a/src/main/java/com/mss/prm_project/service/PaperService.java
+++ b/src/main/java/com/mss/prm_project/service/PaperService.java
@@ -33,7 +33,7 @@ public interface PaperService {
 
     boolean deletePaper(long paperId);
 
-    boolean deleteFavoritePaper(long favoritePaperId);
+    boolean deleteFavoritePaper(long paperId);
 
     List<FavoritePaperDTO> getFavoriteByUser();
 

--- a/src/main/java/com/mss/prm_project/service/ReadingProgressService.java
+++ b/src/main/java/com/mss/prm_project/service/ReadingProgressService.java
@@ -12,4 +12,5 @@ public interface ReadingProgressService {
 
     List<ReadingProgressDTO> getPersonalReadingProgress();
 
+    List<ReadingProgressDTO> getRecentRead();
 }

--- a/src/main/java/com/mss/prm_project/service/serviceimpl/PaperServiceImpl.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/PaperServiceImpl.java
@@ -217,8 +217,10 @@ public class PaperServiceImpl implements PaperService {
     }
 
     @Override
-    public boolean deleteFavoritePaper(long favoritePaperId) {
-        FavoritePaper favoritePaper = favoritePaperRepository.findById(favoritePaperId).orElseThrow(null);
+    public boolean deleteFavoritePaper(long paperId) {
+        String username = SecurityUtils.getCurrentUserName().get();
+        User user = userRepository.findByUsername(username).get();
+        FavoritePaper favoritePaper = favoritePaperRepository.findByUserUserIdAndPaperPaperId(user.getUserId(), (int)paperId);
         if (favoritePaper == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Favorite Paper not found");
         }

--- a/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingProgressServiceImpl.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingProgressServiceImpl.java
@@ -125,7 +125,16 @@ public class ReadingProgressServiceImpl implements ReadingProgressService {
                 }
             }
         }
-        List<ReadingProgress> results = readingProgressRepository.getAllByUserUserId(user.getUserId());
+        List<ReadingProgress> results = readingProgressRepository.getAllByUserUserIdOrderByUpdatedAt(user.getUserId());
+        return results.stream().map(ReadingProgressMapper.INSTANCE::toDTO).toList();
+    }
+
+    @Override
+    public List<ReadingProgressDTO> getRecentRead() {
+        String username = SecurityUtils.getCurrentUserName().get();
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        List<ReadingProgress> results = readingProgressRepository.getAllByUserUserIdOrderByUpdatedAt(user.getUserId());
         return results.stream().map(ReadingProgressMapper.INSTANCE::toDTO).toList();
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Implement recently-read functionality and refine favorite paper deletion to use paperId and current user context.

New Features:
- Add GET /reading-progress/recently-read endpoint and getRecentRead service to retrieve reading progress sorted by update time.
- Include collectionName in ReadingProgressDTO and map it from the entity's collection.
- Change deleteFavoritePaper to accept a paperId and delete the current user's favorite paper.

Enhancements:
- Order reading progress queries by updatedAt in service and repository.
- Remove unused getRecentlyRead stub from PaperController.
- Align repository and service method signatures to use paperId for favorite operations.