### PR TITLE
feature/favourite-recent-read

### DIFF
--- a/src/main/java/com/mss/prm_project/repository/ReadingProgressRepository.java
+++ b/src/main/java/com/mss/prm_project/repository/ReadingProgressRepository.java
@@ -44,6 +44,6 @@ public interface ReadingProgressRepository extends JpaRepository<ReadingProgress
 
     List<ReadingProgress> getAllByUserUserId(int userId);
 
-    List<ReadingProgress> getAllByUserUserIdOrderByUpdatedAt(int userId);
+    List<ReadingProgress> getAllByUserUserIdOrderByUpdatedAtDesc(int userId);
 
 }

--- a/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingProgressServiceImpl.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingProgressServiceImpl.java
@@ -36,7 +36,7 @@ public class ReadingProgressServiceImpl implements ReadingProgressService {
         }else {
             checking = readingProgressRepository.findByUserUserIdAndPaperPaperId(user.getUserId(), paperId);
         }
-        if (readingProgress == null) {
+        if (readingProgress == null && checking.isEmpty()) {
             readingProgress = new ReadingProgress();
             readingProgress.setUser(user);
             readingProgress.setPaper(paper);
@@ -125,7 +125,7 @@ public class ReadingProgressServiceImpl implements ReadingProgressService {
                 }
             }
         }
-        List<ReadingProgress> results = readingProgressRepository.getAllByUserUserIdOrderByUpdatedAt(user.getUserId());
+        List<ReadingProgress> results = readingProgressRepository.getAllByUserUserIdOrderByUpdatedAtDesc(user.getUserId());
         return results.stream().map(ReadingProgressMapper.INSTANCE::toDTO).toList();
     }
 
@@ -134,7 +134,7 @@ public class ReadingProgressServiceImpl implements ReadingProgressService {
         String username = SecurityUtils.getCurrentUserName().get();
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
-        List<ReadingProgress> results = readingProgressRepository.getAllByUserUserIdOrderByUpdatedAt(user.getUserId());
+        List<ReadingProgress> results = readingProgressRepository.getAllByUserUserIdOrderByUpdatedAtDesc(user.getUserId());
         return results.stream().map(ReadingProgressMapper.INSTANCE::toDTO).toList();
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Prevent duplicate reading progress entries and ensure reading progress lists are returned in descending order of update time

Bug Fixes:
- Prevent creating a new ReadingProgress when an existing record is found

Enhancements:
- Update getPersonalReadingProgress and getRecentRead services to retrieve records ordered by updatedAt descending
- Rename repository method getAllByUserUserIdOrderByUpdatedAt to getAllByUserUserIdOrderByUpdatedAtDesc and update calls accordingly