### PR TITLE
feature: fix bug personal reading

### DIFF
--- a/src/main/java/com/mss/prm_project/repository/ReadingProgressRepository.java
+++ b/src/main/java/com/mss/prm_project/repository/ReadingProgressRepository.java
@@ -42,6 +42,15 @@ public interface ReadingProgressRepository extends JpaRepository<ReadingProgress
     """)
     List<ReadingProgress>  findByUserUserIdAndPaperPaperId( @Param("userId") int userId,@Param("paperId") int paperId);
 
+    @Query("""
+        SELECT rp
+        FROM ReadingProgress rp
+        WHERE rp.paper.paperId = :paperId
+        AND rp.user.userId = :userId
+        AND rp.collection IS NULL
+    """)
+    ReadingProgress findPaperInPersonal( @Param("userId") int userId,@Param("paperId") int paperId);
+
     List<ReadingProgress> getAllByUserUserId(int userId);
 
     List<ReadingProgress> getAllByUserUserIdOrderByUpdatedAtDesc(int userId);

--- a/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingProgressServiceImpl.java
+++ b/src/main/java/com/mss/prm_project/service/serviceimpl/ReadingProgressServiceImpl.java
@@ -29,14 +29,13 @@ public class ReadingProgressServiceImpl implements ReadingProgressService {
         User user = userRepository.findByUsername(SecurityUtils.getCurrentUserName().get()).get();
         Paper paper = paperRepository.findById((long)paperId).orElseThrow(()-> new IllegalArgumentException("Paper not found"));
         Collection collection = collectionRepository.findById((long)collectionId).orElse(null);
-        List<ReadingProgress> checking = new ArrayList<>();
         ReadingProgress readingProgress = null;
         if (collectionId >0) {
             readingProgress = readingProgressRepository.findByUserUserIdAndPaperPaperIdCollectionCollectionId(user.getUserId(), paperId, collectionId);
         }else {
-            checking = readingProgressRepository.findByUserUserIdAndPaperPaperId(user.getUserId(), paperId);
+            readingProgress = readingProgressRepository.findPaperInPersonal(user.getUserId(), paperId);
         }
-        if (readingProgress == null && checking.isEmpty()) {
+        if (readingProgress == null) {
             readingProgress = new ReadingProgress();
             readingProgress.setUser(user);
             readingProgress.setPaper(paper);


### PR DESCRIPTION
## Summary by Sourcery

Add a repository query for personal reading progress and refactor the service to use it when creating reading progress without a collection, removing the old list-based check to fix personal reading handling.

Bug Fixes:
- Fix incorrect handling of personal reading progress creation when no collection is provided.

Enhancements:
- Add findPaperInPersonal repository method to retrieve a user's personal reading progress by paper ID.
- Refactor service to use the new findPaperInPersonal method and remove obsolete list-based existence check.